### PR TITLE
Fixed react DOM initialization in some test examples

### DIFF
--- a/tests/pages/navigation/horizontal/index.js
+++ b/tests/pages/navigation/horizontal/index.js
@@ -3,4 +3,5 @@ import { Simple } from '../../../components/Simple';
 import '../../../styles/common.css';
 
 const app = document.getElementById('app');
-ReactDOM.render(<Simple horizontal />, app);
+const root = createRoot(app);
+root.render(<Simple horizontal />);

--- a/tests/pages/navigation/vertical/index.js
+++ b/tests/pages/navigation/vertical/index.js
@@ -3,4 +3,5 @@ import { Simple } from '../../../components/Simple';
 import '../../../styles/common.css';
 
 const app = document.getElementById('app');
-ReactDOM.render(<Simple />, app);
+const root = createRoot(app);
+root.render(<Simple />);


### PR DESCRIPTION
Поправил инициализация реакта.
 Видимо остались артефакты при переходе на новую версию реакта.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.0.2--canary.2.4028016401.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/spatial@3.0.2--canary.2.4028016401.0
  # or 
  yarn add @salutejs/spatial@3.0.2--canary.2.4028016401.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
